### PR TITLE
Backward compatibility with pre apt binary systems

### DIFF
--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
@@ -36,9 +36,9 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 {
 	private static final String PACKAGE_MANAGER = "apt";
 	
-	private static final String SOFTWARE_INSTALLED_VERSION = "apt policy";
-	private static final String SOFTWARE_DETAIL_CMD = "apt show";
-	public static final String SOFTWARE_LIST_CMD = "apt list --installed";
+        private static final String SOFTWARE_INSTALLED_VERSION = "apt-cache show";
+        private static final String SOFTWARE_DETAIL_CMD = "apt-cache show";
+        public static final String SOFTWARE_LIST_CMD = "apt-cache pkgnames";	
 	
 	private ProcessBuilder processBuilder = new ProcessBuilder();
 	
@@ -55,9 +55,9 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 */
 	public Bom generateSBom()
 	{
-		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '/',
-				"");
-
+		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '\n',
+                                null);
+		
 		Bom bom = new Bom();
 		
 		if (logger.isDebugEnabled())
@@ -162,7 +162,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 			while ((line = reader.readLine()) != null)
 			{
 				line = line.trim();
-				if (line.startsWith("Installed"))
+				if (line.startsWith("Installed") || line.startsWith("Version"))
 				{
 					int index = line.indexOf(':');
 					version = line.substring(index + 1).trim();

--- a/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
+++ b/src/main/java/org/cyclonedx/contrib/com/lmco/efoss/unix/sbom/generator/UbuntuSBomGenerator.java
@@ -38,7 +38,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	
         private static final String SOFTWARE_INSTALLED_VERSION = "apt-cache show";
         private static final String SOFTWARE_DETAIL_CMD = "apt-cache show";
-        public static final String SOFTWARE_LIST_CMD = "apt-cache pkgnames";	
+        public static final String SOFTWARE_LIST_CMD = "dpkg --get-selections";
 	
 	private ProcessBuilder processBuilder = new ProcessBuilder();
 	
@@ -55,7 +55,7 @@ public class UbuntuSBomGenerator extends UnixSBomGenerator
 	 */
 	public Bom generateSBom()
 	{
-		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '\n',
+		List<String> softwareList = generateListOfSoftware(SOFTWARE_LIST_CMD, '\t',
                                 null);
 		
 		Bom bom = new Bom();


### PR DESCRIPTION
Use apt-cache rather than apt as the latter:
1. Didn't exist in older linux variants
2. Doesn't have a stable command line interface